### PR TITLE
Additional rules to better error on bad code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,6 +75,29 @@ module.exports = {
     'object-shorthand': ['error', 'properties'],
     'no-unsafe-finally': 'error',
     'no-useless-computed-key': 'error',
-    'require-await': 'error'
+    'require-await': 'error',
+    'constructor-super': 'error',
+    'no-buffer-constructor': 'error',
+    'no-mixed-requires': 'error',
+    'no-new-require': 'error',
+    'no-caller': 'error',
+    'no-const-assign': 'error',
+    'no-dupe-class-members': 'error',
+    'no-class-assign': 'warn',
+    'no-new-symbol': 'error',
+    'no-this-before-super': 'error',
+    'prefer-rest-params': 'error',
+    'prefer-spread': 'error',
+    'no-useless-call': 'error',
+    'rest-spread-spacing': ['error', 'never'],
+    'padding-line-between-statements': ['error',
+      { blankLine: 'always', prev: 'directive', next: '*' },
+      { blankLine: 'any', prev: 'directive', next: 'directive' },
+      { blankLine: 'always', prev: 'cjs-import', next: '*' },
+      { blankLine: 'any', prev: 'cjs-import', next: 'cjs-import' },
+      { blankLine: 'always', prev: 'cjs-export', next: '*' },
+      { blankLine: 'always', prev: 'multiline-block-like', next: '*' },
+      { blankLine: 'always', prev: 'class', next: '*' }
+    ]
   }
 };

--- a/test/fixtures/hapi-capitalize-modules.js
+++ b/test/fixtures/hapi-capitalize-modules.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-unused-vars */
 'use strict';
+
 const Fs = require('fs');
 const net = require('net');
+
 const fn = function () {
 
     const Assert = require('assert');

--- a/test/fixtures/hapi-for-you.js
+++ b/test/fixtures/hapi-for-you.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 'use strict';
+
 const arr = [];
 
 for (let i = 0; i < arr.length; ++i) {

--- a/test/fixtures/indent-switch-case.js
+++ b/test/fixtures/indent-switch-case.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const foo = 'foo';
 let result = 0;
 

--- a/test/fixtures/no-constant-condition.js
+++ b/test/fixtures/no-constant-condition.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 'use strict';
+
 if ((foo) => 1) {
     // Do nothing
 }

--- a/test/fixtures/no-undef.js
+++ b/test/fixtures/no-undef.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 'use strict';
+
 try {
     const foo = typeof bar;
     const baz = bar;

--- a/test/fixtures/no-useless-computed-key.js
+++ b/test/fixtures/no-useless-computed-key.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+/* eslint-disable strict, padding-line-between-statements */
 module.exports.a = { ['0']: 0 };
 module.exports.a = { ['0+1,234']: 0 };
 module.exports.a = { [0]: 0 };

--- a/test/fixtures/no-var.js
+++ b/test/fixtures/no-var.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 'use strict';
+
 var foo = 1;
 let bar = 2;
 const baz = 3;

--- a/test/fixtures/one-var.js
+++ b/test/fixtures/one-var.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars, prefer-const */
 'use strict';
+
 const foo = 1;
 let bar;
 let baz, quux;

--- a/test/fixtures/prefer-arrow-callback.js
+++ b/test/fixtures/prefer-arrow-callback.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars, handle-callback-err */
 'use strict';
+
 const foo = (arg, callback) => {
 
     return callback(null, arg + 1);

--- a/test/index.js
+++ b/test/index.js
@@ -104,7 +104,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('indent');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Expected indentation of 4 spaces but found 0.');
-    expect(msg.line).to.equal(10);
+    expect(msg.line).to.equal(11);
     expect(msg.column).to.equal(1);
     expect(msg.nodeType).to.equal('Keyword');
     expect(msg.source).to.equal('case \'bar\':');
@@ -114,7 +114,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('indent');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Expected indentation of 8 spaces but found 4.');
-    expect(msg.line).to.equal(11);
+    expect(msg.line).to.equal(12);
     expect(msg.column).to.equal(1);
     expect(msg.nodeType).to.equal('Identifier');
     expect(msg.source).to.equal('    result = 2;');
@@ -124,7 +124,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('indent');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Expected indentation of 8 spaces but found 4.');
-    expect(msg.line).to.equal(12);
+    expect(msg.line).to.equal(13);
     expect(msg.column).to.equal(1);
     expect(msg.nodeType).to.equal('Keyword');
     expect(msg.source).to.equal('    break;');
@@ -134,7 +134,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('indent');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Expected indentation of 8 spaces but found 4.');
-    expect(msg.line).to.equal(14);
+    expect(msg.line).to.equal(15);
     expect(msg.column).to.equal(1);
     expect(msg.nodeType).to.equal('Identifier');
     expect(msg.source).to.equal('    result = 3;');
@@ -144,7 +144,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('indent');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Expected indentation of 8 spaces but found 4.');
-    expect(msg.line).to.equal(15);
+    expect(msg.line).to.equal(16);
     expect(msg.column).to.equal(1);
     expect(msg.nodeType).to.equal('Keyword');
     expect(msg.source).to.equal('    break;');
@@ -214,7 +214,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('hapi/hapi-for-you');
     expect(msg.severity).to.equal(1);
     expect(msg.message).to.equal('Expected iterator \'j\', but got \'k\'.');
-    expect(msg.line).to.equal(6);
+    expect(msg.line).to.equal(7);
     expect(msg.column).to.equal(5);
     expect(msg.nodeType).to.equal('ForStatement');
     expect(msg.source).to.equal('    for (let k = 0; k < arr.length; k++) {');
@@ -224,7 +224,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('hapi/hapi-for-you');
     expect(msg.severity).to.equal(1);
     expect(msg.message).to.equal('Update to iterator should use prefix operator.');
-    expect(msg.line).to.equal(6);
+    expect(msg.line).to.equal(7);
     expect(msg.column).to.equal(5);
     expect(msg.nodeType).to.equal('ForStatement');
     expect(msg.source).to.equal('    for (let k = 0; k < arr.length; k++) {');
@@ -264,7 +264,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('hapi/hapi-capitalize-modules');
     expect(msg.severity).to.equal(1);
     expect(msg.message).to.equal('Imported module variable name not capitalized.');
-    expect(msg.line).to.equal(4);
+    expect(msg.line).to.equal(5);
     expect(msg.column).to.equal(7);
     expect(msg.nodeType).to.equal('VariableDeclarator');
     expect(msg.source).to.equal('const net = require(\'net\');');
@@ -324,7 +324,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('one-var');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Split \'let\' declarations into multiple statements.');
-    expect(msg.line).to.equal(5);
+    expect(msg.line).to.equal(6);
     expect(msg.column).to.equal(1);
     expect(msg.nodeType).to.equal('VariableDeclaration');
     expect(msg.source).to.equal('let baz, quux;');
@@ -345,7 +345,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('no-undef');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('\'bar\' is not defined.');
-    expect(msg.line).to.equal(5);
+    expect(msg.line).to.equal(6);
     expect(msg.column).to.equal(17);
     expect(msg.nodeType).to.equal('Identifier');
     expect(msg.source).to.equal('    const baz = bar;');
@@ -405,7 +405,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('hapi/hapi-no-var');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Unexpected var, use let or const instead.');
-    expect(msg.line).to.equal(3);
+    expect(msg.line).to.equal(4);
     expect(msg.column).to.equal(1);
     expect(msg.nodeType).to.equal('VariableDeclaration');
     expect(msg.source).to.equal('var foo = 1;');
@@ -493,7 +493,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('prefer-arrow-callback');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Unexpected function expression.');
-    expect(msg.line).to.equal(21);
+    expect(msg.line).to.equal(22);
     expect(msg.column).to.equal(8);
     expect(msg.nodeType).to.equal('FunctionExpression');
     expect(msg.source).to.equal('foo(4, function (err, value) {');
@@ -513,7 +513,7 @@ describe('eslint-config-hapi', () => {
     expect(msg.ruleId).to.equal('no-constant-condition');
     expect(msg.severity).to.equal(2);
     expect(msg.message).to.equal('Unexpected constant condition.');
-    expect(msg.line).to.equal(3);
+    expect(msg.line).to.equal(4);
     expect(msg.column).to.equal(5);
     expect(msg.nodeType).to.equal('ArrowFunctionExpression');
     expect(msg.source).to.equal('if ((foo) => 1) {');


### PR DESCRIPTION
I added a bunch of rules that enables stricter checking of idiomatic hapi.js code.

Details:

 * `constructor-super` - Helps writing valid JS.
 * `no-buffer-constructor` - Avoids using deprecated `new Buffer()`.
 * `no-mixed-requires` - Helps enforce require style.
 * `no-new-require` - Helps enforce require style.
 * `no-caller` - Helps writing valid JS.
 * `no-const-assign` - Helps writing valid JS.
 * `no-dupe-class-members'` - Helps writing valid JS.
 * `no-class-assign` - Avoids bad / incorrect code.
 * `no-new-symbol` - Helps writing valid JS.
 * `no-this-before-super` - Helps writing valid JS.
 * `prefer-rest-params` - Disallow `arguments` (opinionated).
 * `prefer-spread` - Helps writing modern JS (opinionated).
 * `no-useless-call` - Helps writing modern JS (opinionated).
 * `rest-spread-spacing` - No space after `...` (opinionated, but matches current usage in code).
 * `padding-line-between-statements` - Helps enforce style guide.

When these rules are applied to the hapi code, the only required changes are some extra empty lines from failing `padding-line-between-statements`. In all cases due to the code not following the styleguide.

The lines I have marked with _opinionated_, should probably also be reflected in the style guide. It's mainly dropping all usage of `arguments` (which V8 doesn't like), and avoiding `.apply()` and `.call()` whenever possible. These are pre-ES6 constructs that should be updated.